### PR TITLE
fix: prevent interactive ujust prompt hijacking

### DIFF
--- a/src/bazzite_mcp/runner.py
+++ b/src/bazzite_mcp/runner.py
@@ -26,6 +26,8 @@ def run_command(command: str, timeout: int = 120) -> CommandResult:
         capture_output=True,
         text=True,
         timeout=timeout,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
     )
     stdout = result.stdout.strip()
     # Surface guardrail warnings directly in output so they always reach the user
@@ -65,11 +67,15 @@ def run_audited(
             tool=tool,
             command=command,
             args=json.dumps(args) if args else None,
-            result="success" if result.returncode == 0 else f"failed (exit {result.returncode})",
+            result="success"
+            if result.returncode == 0
+            else f"failed (exit {result.returncode})",
             output=(result.stdout[:500] if result.stdout else None),
             rollback=rollback,
         )
     except Exception as exc:
-        logger.error("Audit logging failed for tool=%s command=%s: %s", tool, command, exc)
+        logger.error(
+            "Audit logging failed for tool=%s command=%s: %s", tool, command, exc
+        )
         result.warning = (result.warning or "") + f" [AUDIT FAILED: {exc}]"
     return result

--- a/src/bazzite_mcp/tools/ujust.py
+++ b/src/bazzite_mcp/tools/ujust.py
@@ -5,9 +5,11 @@ from bazzite_mcp.runner import run_audited, run_command
 
 def ujust_list(filter: str | None = None) -> str:
     """List available ujust commands, optionally filtered by keyword."""
-    result = run_command("ujust --summary 2>/dev/null || ujust 2>&1")
+    result = run_command("ujust --summary")
     if result.returncode != 0:
-        return f"Error listing ujust commands: {result.stderr}"
+        result = run_command("ujust")
+        if result.returncode != 0:
+            return f"Error listing ujust commands: {result.stderr}"
 
     lines = result.stdout.strip().split("\n") if result.stdout.strip() else []
     if filter:
@@ -33,6 +35,31 @@ def ujust_run(command: str) -> str:
         parts = shlex.split(command)
     except ValueError:
         return "Invalid command syntax."
+
+    if not parts:
+        return "Missing ujust command."
+
+    recipe = parts[0]
+    if len(parts) >= 2 and parts[1] in {"help", "--help", "-h"}:
+        usage = run_command(f"ujust --usage {shlex.quote(recipe)}")
+        if usage.returncode == 0 and usage.stdout.strip():
+            return usage.stdout
+        fallback = run_command(f"ujust --show {shlex.quote(recipe)}")
+        if fallback.returncode == 0 and fallback.stdout.strip():
+            return fallback.stdout
+        return f"Could not retrieve usage for '{recipe}'."
+
+    recipe_source = run_command(f"ujust --show {shlex.quote(recipe)}")
+    if (
+        recipe_source.returncode == 0
+        and len(parts) == 1
+        and "Choose" in recipe_source.stdout
+    ):
+        return (
+            f"'{recipe}' appears interactive. Pass an explicit non-interactive option "
+            "(for example: '<recipe> help') or inspect it with ujust_show first."
+        )
+
     result = run_audited(
         f"ujust {shlex.join(parts)}",
         tool="ujust_run",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,6 @@
 import pytest
+import subprocess
+from unittest.mock import MagicMock, patch
 
 from bazzite_mcp.guardrails import GuardrailError
 from bazzite_mcp.runner import run_command, run_audited
@@ -39,8 +41,20 @@ def test_run_audited_logs_action(tmp_path, monkeypatch) -> None:
     assert "installed" in result.stdout
 
     from bazzite_mcp.audit import AuditLog
+
     log = AuditLog()
     entries = log.query(tool="install_package")
     assert len(entries) == 1
     assert entries[0]["rollback"] == "brew uninstall test"
     assert entries[0]["result"] == "success"
+
+
+@patch("bazzite_mcp.runner.subprocess.run")
+def test_run_command_non_interactive_execution(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+
+    run_command("echo hello")
+
+    _, kwargs = mock_run.call_args
+    assert kwargs["stdin"] == subprocess.DEVNULL
+    assert kwargs["start_new_session"] is True

--- a/tests/test_tools_ujust.py
+++ b/tests/test_tools_ujust.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from bazzite_mcp.tools.ujust import ujust_list, ujust_show
+from bazzite_mcp.tools.ujust import ujust_list, ujust_run, ujust_show
 
 
 @patch("bazzite_mcp.tools.ujust.run_command")
@@ -28,6 +28,63 @@ def test_ujust_list_with_filter(mock_run: MagicMock) -> None:
 
 @patch("bazzite_mcp.tools.ujust.run_command")
 def test_ujust_show(mock_run: MagicMock) -> None:
-    mock_run.return_value = MagicMock(returncode=0, stdout="#!/bin/bash\necho hello", stderr="")
+    mock_run.return_value = MagicMock(
+        returncode=0, stdout="#!/bin/bash\necho hello", stderr=""
+    )
     result = ujust_show("update")
     assert "echo hello" in result
+
+
+@patch("bazzite_mcp.tools.ujust.run_command")
+def test_ujust_list_falls_back_to_full_list(mock_run: MagicMock) -> None:
+    mock_run.side_effect = [
+        MagicMock(returncode=1, stdout="", stderr="unknown option --summary"),
+        MagicMock(returncode=0, stdout="update\nsetup-waydroid", stderr=""),
+    ]
+
+    result = ujust_list()
+
+    assert "update" in result
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0] == "ujust --summary"
+    assert mock_run.call_args_list[1].args[0] == "ujust"
+
+
+@patch("bazzite_mcp.tools.ujust.run_command")
+def test_ujust_run_help_uses_usage(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(returncode=0, stdout="usage output", stderr="")
+
+    result = ujust_run("setup-virtualization help")
+
+    assert result == "usage output"
+    mock_run.assert_called_once_with("ujust --usage setup-virtualization")
+
+
+@patch("bazzite_mcp.tools.ujust.run_command")
+def test_ujust_run_blocks_interactive_recipe_without_option(
+    mock_run: MagicMock,
+) -> None:
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout='my_recipe:\n    OPTION=$(Choose "one" "two")',
+        stderr="",
+    )
+
+    result = ujust_run("my_recipe")
+
+    assert "appears interactive" in result
+
+
+@patch("bazzite_mcp.tools.ujust.run_audited")
+@patch("bazzite_mcp.tools.ujust.run_command")
+def test_ujust_run_executes_non_interactive_recipe(
+    mock_run_command: MagicMock,
+    mock_run_audited: MagicMock,
+) -> None:
+    mock_run_command.return_value = MagicMock(returncode=0, stdout="recipe", stderr="")
+    mock_run_audited.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+
+    result = ujust_run("update")
+
+    assert result == "ok"
+    mock_run_audited.assert_called_once()


### PR DESCRIPTION
## Summary
- run commands in a detached, non-interactive subprocess (`stdin=DEVNULL`, new session) to prevent TTY input capture
- make `ujust_run <recipe> help` resolve via `ujust --usage` / `--show` instead of executing recipe bodies with side effects
- detect interactive `Choose` recipes and return a safe non-interactive guidance message
- update `ujust_list` to avoid `/dev/null` redirection blocked by guardrails
- add regression tests for runner non-interactive execution and ujust safety flows

## Validation
- `uv run pytest -q tests/test_runner.py tests/test_tools_ujust.py`

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/rolandmarg/bazzite-mcp/2?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->